### PR TITLE
Update CODEOWNERS to be DevOps team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pankajnarang
+* @cheddartv/DevOps


### PR DESCRIPTION
## Summary
Updating the CODEOWNERS file to be the whole team as this repo is owned by the DevOps team.